### PR TITLE
Be more tolerant about request Content-Type header

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -76,7 +76,7 @@ def healthz():
 @app.route('/register', methods=['POST'])
 def register():
     with open_database(db_file, lock=True) as db:
-        content = request.get_json()
+        content = request.get_json(force=True)
         hostname = content.get('hostname')
         targets = content.get('targets', [])
         labels = content.get('labels', {})


### PR DESCRIPTION
Busybox's wget and OpenWrt's uclient-fetch don't provide flags to set request headers. With `force=True`, the Content-Type header is ignored and the data is always parsed as JSON.